### PR TITLE
Lazyload

### DIFF
--- a/client/util-components/LazyLoad.jsx
+++ b/client/util-components/LazyLoad.jsx
@@ -1,0 +1,40 @@
+import React, { Component } from "react";
+
+class LazyLoad extends Component {
+	constructor(){
+		super();
+		this.state = {
+			mod: null
+		};
+	}
+
+	componentWillMount() {
+		this.load(this.props);
+	}
+
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.load !== this.props.load) {
+			this.load(nextProps);
+		}
+	}
+
+	load(props) {
+		this.setState({
+			mod: null
+		});
+		props.load((mod) => {
+			this.setState({
+				mod: mod.default ? mod.default : mod
+			});
+		});
+	}
+
+	render() {
+		if(this.state.mod)
+			return this.props.children(this.state.mod);
+		else
+        return null;
+	}
+}
+
+export default LazyLoad;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-plugin-dynamic-import-webpack": "^1.0.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
+    "bundle-loader": "^0.5.5",
     "css-loader": "^0.28.4",
     "eslint": "^3.19.0",
     "eslint-plugin-react": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,6 +850,12 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+bundle-loader@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/bundle-loader/-/bundle-loader-0.5.5.tgz#11fd7b08edf86a1d708efcb1eca62ca51f6c368a"
+  dependencies:
+    loader-utils "^1.0.2"
+
 bytes@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.3.0.tgz#d5b680a165b6201739acb611542aabc2d8ceb070"


### PR DESCRIPTION
<LazyLoad> Component to Lazy Load React Components added.

## Usage - 
 Example 
```
import loadComponent from "bundle-loader?lazy!./Component";

const Component  = () = > (
	<LazyLoad load={loadComponent}>{(Component)=><Component/>}</LazyLoad>
);

...

componentDidMount(){
	loadComponent(()=>{}) //Load the Component Async Beforehand.
}
...

```

For more info check ... [ReactTraining / React Router / CodeSplitting ](https://reacttraining.com/react-router/web/guides/code-splitting)